### PR TITLE
chore: shorten import path for lib related stuffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 AutoInjectable is a utility library designed to simplify the usage of dependency injection
 in [Nest](https://github.com/nestjs/nest). It enables seamless
 handling of automatic injection of dependencies by the framework.
+With this library, you can inject dependencies into classes without the need for module definitions.
 
 ## Features
 
@@ -61,8 +62,23 @@ npm install @tiny-nestjs/auto-injectable
     }
     ```
 
-   On this case, by applying `@AutoInjectable()` decorator to the CatService class, the class can now be
-   automatically injected into other modules.
+   In this case, by applying the @AutoInjectable() decorator to the CatService class, the class has become injectable, allowing it to be injected into other modules without the need for module definitions.
+
+**3. Inject your class**
+
+   ```
+   @Controller()
+   export class AppController {
+     constructor(private readonly catService: CatService) {}
+   
+     @Get('cats')
+     getCats() {
+       return this.catService.findAll();
+     }
+   }
+   ```
+
+   The class with the @AutoInjectable() decorator has been successfully injected.
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npm install @tiny-nestjs/auto-injectable
 
    In this case, by applying the @AutoInjectable() decorator to the CatService class, the class has become injectable, allowing it to be injected into other modules without the need for module definitions.
 
-**3. Inject your class**
+**3. Inject**
 
    ```
    @Controller()

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,21 +1,12 @@
 import { Controller, Get } from '@nestjs/common';
 import { CatService } from './modules/cat/cat.service';
-import { AppService } from './app.service';
 
 @Controller()
 export class AppController {
-  constructor(
-    private readonly appService: AppService,
-    private readonly catService: CatService,
-  ) {}
-
-  @Get()
-  getHello(): string {
-    return this.appService.getHello();
-  }
+  constructor(private readonly catService: CatService) {}
 
   @Get('cats')
-  getCats(): string {
-    return JSON.stringify(this.catService.findAll());
+  getCats() {
+    return this.catService.findAll();
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { AppService } from './app.service';
 import { AppController } from './app.controller';
-import { ComponentScan } from './lib/decorators/component-scan.decorator';
+import { ComponentScan } from './lib';
 
 @ComponentScan()
 @Module({

--- a/src/lib/auto.module.ts
+++ b/src/lib/auto.module.ts
@@ -1,5 +1,5 @@
 import { DynamicModule, Module } from '@nestjs/common';
-import { Importer } from './core/importer';
+import { Importer } from './core';
 
 @Module({})
 export class AutoModule {

--- a/src/lib/core/importer.ts
+++ b/src/lib/core/importer.ts
@@ -1,6 +1,6 @@
 import { glob } from 'glob';
 import { resolve } from 'path';
-import { AUTO_INJECTABLE_WATERMARK } from '../interfaces/auto-injectable.constant';
+import { AUTO_INJECTABLE_WATERMARK } from '../interfaces';
 
 type ClassType = new (...args: any[]) => any;
 

--- a/src/lib/decorators/auto-injectable.decorator.spec.ts
+++ b/src/lib/decorators/auto-injectable.decorator.spec.ts
@@ -1,4 +1,4 @@
-import { AUTO_INJECTABLE_WATERMARK } from '../interfaces/auto-injectable.constant';
+import { AUTO_INJECTABLE_WATERMARK } from '../interfaces';
 import { AutoInjectable } from './auto-injectable.decorator';
 
 describe('AutoInjectable decorator', () => {

--- a/src/lib/decorators/auto-injectable.decorator.ts
+++ b/src/lib/decorators/auto-injectable.decorator.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { AUTO_INJECTABLE_WATERMARK } from '../interfaces/auto-injectable.constant';
+import { AUTO_INJECTABLE_WATERMARK } from '../interfaces';
 
 export function AutoInjectable(): ClassDecorator {
   return (target: object) => {

--- a/src/modules/cat/cat.service.ts
+++ b/src/modules/cat/cat.service.ts
@@ -1,5 +1,5 @@
 import { Cat } from './cat.interface';
-import { AutoInjectable } from '../../lib/decorators/auto-injectable.decorator';
+import { AutoInjectable } from '../../lib';
 
 @AutoInjectable()
 export class CatService {


### PR DESCRIPTION
### 1. Shorten import path

**example**

```ts
// before
import { Cat } from './cat.interface';
import { AutoInjectable } from '../../lib/decorators/auto-injectable.decorator';

@AutoInjectable()
export class CatService {
  private readonly cats: Cat[] = [
    {
      name: 'test-cat',
      age: 5,
    },
  ];

  create(cat: Cat) {
    this.cats.push(cat);
  }

  findAll(): Cat[] {
    return this.cats;
  }
}
```

```ts
// after
import { Cat } from './cat.interface';
import { AutoInjectable } from '../../lib';

@AutoInjectable()
export class CatService {
  private readonly cats: Cat[] = [
    {
      name: 'test-cat',
      age: 5,
    },
  ];

  create(cat: Cat) {
    this.cats.push(cat);
  }

  findAll(): Cat[] {
    return this.cats;
  }
}
```

### 2. Update README.md

- Add a third section to provide users with clearer instructions on how to use the library