### PR TITLE
fix: `issue#44` more `Nest` like error

### DIFF
--- a/lib/core/importer.ts
+++ b/lib/core/importer.ts
@@ -25,6 +25,7 @@ interface AutoClasses {
 }
 
 export class Importer {
+  private classMap = new Map<ClassType, string>();
   private rootPath = '';
 
   static load(patterns: string[]): AutoClasses {
@@ -91,6 +92,7 @@ export class Importer {
   private catchOverlappedScanScope(value: { new (...args: any[]): any; name: string }, pathName: string) {
     locate(value as any).then(({ path }: { path: string }) => {
       if (!this.rootPath) this.rootPath = pathName;
+      this.classMap.set(value, path);
       if (this.rootPath !== path) {
         new Logger('ExceptionHandler').error(
           `ComponentScan() module scope cannot be overlapped.\n\nPotential causes:\n- An overlapped dependency between modules.\n- Please check the module in '${this.rootPath}' and '${path}'\n\nScope [${value.name}]`,

--- a/lib/core/importer.ts
+++ b/lib/core/importer.ts
@@ -25,7 +25,7 @@ interface AutoClasses {
 }
 
 export class Importer {
-  private classMap = new Map<ClassType, string>();
+  private classMap = new Map<string, ClassType>();
   private rootPath = '';
 
   static load(patterns: string[]): AutoClasses {
@@ -91,11 +91,13 @@ export class Importer {
    */
   private catchOverlappedScanScope(value: { new (...args: any[]): any; name: string }, pathName: string) {
     locate(value as any).then(({ path }: { path: string }) => {
+      this.classMap.set(path, value);
       if (!this.rootPath) this.rootPath = pathName;
-      this.classMap.set(value, path);
       if (this.rootPath !== path) {
         new Logger('ExceptionHandler').error(
-          `ComponentScan() module scope cannot be overlapped.\n\nPotential causes:\n- An overlapped dependency between modules.\n- Please check the module in '${this.rootPath}' and '${path}'\n\nScope [${value.name}]`,
+          `ComponentScan() module scope cannot be overlapped.\n\nPotential causes:\n- An overlapped dependency between modules.\n- Please check the module in '${
+            this.rootPath
+          }' and '${path}'\n\nScope [${value.name} -> ${this.classMap.get(this.rootPath)!.name}]`,
         );
         process.exit(1);
       }


### PR DESCRIPTION
## Description
- fix the [issue#44](https://github.com/tiny-nestjs/auto-injectable/issues/44)

Define `classMap` to handle classes and paths that are scanned by the `Importer` class. 
Then, check for any overlapping classes in the `classMap` and display them to the users.

Please check the image below.

<img width="878" alt="image" src="https://github.com/tiny-nestjs/auto-injectable/assets/81916648/f6a09d9b-7a1d-4d1e-a9b5-7b2131d26c91">

## References
- https://github.com/tiny-nestjs/auto-injectable/issues/44

## Checklist
- [x] Add labels and reviewers ?
- [x] Are you fully explaining what you changed ?
- [x] Did you check that there is no conflict with the base branch ?
